### PR TITLE
Create Covey-inspired weekly planner interface

### DIFF
--- a/css/styles.css
+++ b/css/styles.css
@@ -1,73 +1,239 @@
-/* styles.css */
+:root {
+    --background: #ffffff;
+    --text: #000000;
+    --accent: #c1121f;
+    --border: #000000;
+}
+
+* {
+    box-sizing: border-box;
+}
 
 body {
-    font-family: Arial, sans-serif;
     margin: 0;
-    padding: 0;
-    box-sizing: border-box;
+    font-family: "Helvetica Neue", Arial, sans-serif;
+    background-color: var(--background);
+    color: var(--text);
+    line-height: 1.6;
 }
 
-header {
-    text-align: center;
-    margin: 20px 0;
+.planner {
+    max-width: 1200px;
+    margin: 0 auto;
+    padding: 24px 20px 48px;
 }
 
-.container {
+.planner__header {
+    border-bottom: 2px solid var(--border);
+    padding-bottom: 16px;
+    margin-bottom: 32px;
+}
+
+.planner__header h1 {
+    font-size: 2rem;
+    margin: 0 0 8px;
+}
+
+.planner__subtitle {
+    margin: 0 0 16px;
+}
+
+.week-controls {
     display: flex;
     flex-wrap: wrap;
-    margin: 0 auto;
-    padding: 10px;
-    box-sizing: border-box;
+    gap: 12px;
+    align-items: center;
 }
 
-.menu-item {
-    border: 1px solid black;
-    padding: 15px;
-    margin: 10px;
-    background-color: lightgray;
-    position: relative;
-    box-sizing: border-box;
-    flex: 1;
+.week-controls__label {
+    font-weight: 600;
+    display: flex;
+    align-items: center;
+    gap: 8px;
 }
 
-.title {
+.week-controls input[type="date"] {
+    padding: 6px 10px;
+    border: 1px solid var(--border);
+    background-color: var(--background);
+    color: var(--text);
+}
+
+.button {
+    background-color: var(--background);
+    color: var(--text);
+    border: 1px solid var(--border);
+    padding: 6px 14px;
+    font-size: 0.95rem;
+    cursor: pointer;
+    text-transform: uppercase;
+    letter-spacing: 0.04em;
+    transition: background-color 0.2s ease, color 0.2s ease;
+}
+
+.button:hover,
+.button:focus {
+    background-color: var(--accent);
+    color: var(--background);
+    outline: none;
+}
+
+.button:focus-visible {
+    outline: 2px solid var(--accent);
+    outline-offset: 2px;
+}
+
+.button--outline {
+    border-style: dashed;
+}
+
+.planner__section {
+    padding: 24px 0;
+    border-top: 1px solid var(--border);
+}
+
+.section-heading {
+    display: flex;
+    justify-content: space-between;
+    align-items: center;
+    gap: 12px;
+}
+
+.section-heading h2 {
+    margin: 0;
+}
+
+.section-intro {
+    margin: 12px 0 16px;
+    max-width: 72ch;
+}
+
+.highlight {
+    color: var(--accent);
+    font-weight: 600;
+}
+
+.table-wrapper {
+    width: 100%;
+    overflow-x: auto;
+}
+
+.table-wrapper--scroll {
+    border: 1px solid var(--border);
+    border-left: 0;
+    border-right: 0;
+    padding: 12px 0;
+}
+
+.roles-table,
+.schedule-table {
+    width: 100%;
+    border-collapse: collapse;
+}
+
+.roles-table th,
+.roles-table td,
+.schedule-table th,
+.schedule-table td {
+    border: 1px solid var(--border);
+    padding: 8px;
+    vertical-align: top;
+}
+
+.roles-table th,
+.schedule-table th {
+    text-align: left;
+    font-weight: 700;
+}
+
+.roles-table td:last-child {
+    width: 80px;
+    text-align: center;
+}
+
+.roles-table input[type="text"],
+textarea {
+    width: 100%;
+    border: 1px solid var(--border);
+    background-color: var(--background);
+    color: var(--text);
+    padding: 6px;
+    font-size: 0.95rem;
+    resize: vertical;
+    min-height: 40px;
+}
+
+textarea::placeholder,
+input::placeholder {
+    color: var(--text);
+    opacity: 0.6;
+}
+
+textarea:focus,
+input:focus {
+    outline: 2px solid var(--accent);
+    outline-offset: 1px;
+}
+
+.matrix {
+    display: grid;
+    grid-template-columns: repeat(auto-fit, minmax(220px, 1fr));
+    gap: 16px;
+}
+
+.matrix__cell {
+    border: 1px solid var(--border);
+    padding: 12px;
+}
+
+.matrix__cell h3 {
+    margin: 0 0 8px;
+    font-size: 1.05rem;
+    color: var(--accent);
+}
+
+.remove-role {
+    background: none;
+    border: none;
+    color: var(--accent);
+    cursor: pointer;
+    font-size: 0.9rem;
+    text-decoration: underline;
+}
+
+.remove-role:hover,
+.remove-role:focus {
+    text-decoration: none;
+}
+
+.visually-hidden {
     position: absolute;
-    top: 0;
-    right: 0;
-    background-color: lightcoral;
-    padding: 5px;
-    border: 1px solid black;
+    width: 1px;
+    height: 1px;
+    padding: 0;
+    margin: -1px;
+    overflow: hidden;
+    clip: rect(0, 0, 0, 0);
+    white-space: nowrap;
+    border: 0;
 }
 
-#beef .title {
-    background-color: lightseagreen;
-}
-
-#sushi .title {
-    background-color: lightgoldenrodyellow;
-}
-
-/* Desktop View */
-@media (min-width: 992px) {
-    .menu-item {
-        width: calc(33.333% - 40px);
-    }
-}
-
-/* Tablet View */
-@media (min-width: 768px) and (max-width: 991px) {
-    #chicken, #beef {
-        width: calc(50% - 40px);
+@media (max-width: 720px) {
+    .planner {
+        padding: 20px 16px 40px;
     }
 
-    #sushi {
-        width: calc(100% - 40px);
+    .section-heading {
+        flex-direction: column;
+        align-items: flex-start;
     }
-}
 
-/* Mobile View */
-@media (max-width: 767px) {
-    .menu-item {
-        width: calc(100% - 40px);
+    .week-controls {
+        flex-direction: column;
+        align-items: flex-start;
+    }
+
+    .roles-table td:last-child {
+        width: auto;
     }
 }

--- a/index.html
+++ b/index.html
@@ -3,26 +3,142 @@
 <head>
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
-    <title>Our Menu</title>
+    <title>Covey-Inspired Weekly Planner</title>
     <link rel="stylesheet" href="css/styles.css">
+    <script src="js/planner.js" defer></script>
 </head>
 <body>
-    <header>
-        <h1>Our Menu</h1>
-    </header>
-    <div class="container">
-        <section class="menu-item" id="chicken">
-            <div class="title">Chicken</div>
-            <p>Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat.</p>
+    <main class="planner">
+        <header class="planner__header">
+            <h1>Weekly Planner</h1>
+            <p class="planner__subtitle">Organize your roles, goals, and priorities using Stephen Covey's Habit 3 framework.</p>
+            <div class="week-controls">
+                <label class="week-controls__label" for="week-start">Week of
+                    <input type="date" id="week-start" name="week-start">
+                </label>
+                <button type="button" id="reset-planner" class="button">Reset Planner</button>
+            </div>
+        </header>
+
+        <section class="planner__section" aria-labelledby="weekly-focus-title">
+            <h2 id="weekly-focus-title">Weekly Focus</h2>
+            <p class="section-intro"><span class="highlight">Clarify</span> your mission for the week to anchor the schedule around what matters most.</p>
+            <textarea id="weekly-focus" name="weekly-focus" rows="3" placeholder="Define your key outcomes and 'big rocks' for the week..."></textarea>
         </section>
-        <section class="menu-item" id="beef">
-            <div class="title">Beef</div>
-            <p>Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat.</p>
+
+        <section class="planner__section" aria-labelledby="roles-goals-title">
+            <div class="section-heading">
+                <h2 id="roles-goals-title">Roles &amp; Weekly Goals</h2>
+                <button type="button" id="add-role" class="button button--outline">Add Role</button>
+            </div>
+            <p class="section-intro">List the roles you serve and the single most important outcome you will deliver for each. Keep goals specific and aligned with your <span class="highlight">priorities</span>.</p>
+            <div class="table-wrapper">
+                <table class="roles-table">
+                    <thead>
+                        <tr>
+                            <th scope="col">Role</th>
+                            <th scope="col">Weekly Goal</th>
+                            <th scope="col" class="visually-hidden">Actions</th>
+                        </tr>
+                    </thead>
+                    <tbody id="roles-body">
+                        <!-- Rows rendered dynamically -->
+                    </tbody>
+                </table>
+            </div>
         </section>
-        <section class="menu-item" id="sushi">
-            <div class="title">Sushi</div>
-            <p>Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat.</p>
+
+        <section class="planner__section" aria-labelledby="priority-matrix-title">
+            <h2 id="priority-matrix-title">Priority Matrix</h2>
+            <p class="section-intro">Capture tasks inside Covey's quadrants to protect important work and limit distractions.</p>
+            <div class="matrix" role="group" aria-labelledby="priority-matrix-title">
+                <div class="matrix__cell" data-quadrant="q1">
+                    <h3>Q1: Urgent &amp; Important</h3>
+                    <textarea id="quadrant-q1" rows="5" placeholder="Deadlines, crises, and commitments that must happen this week."></textarea>
+                </div>
+                <div class="matrix__cell" data-quadrant="q2">
+                    <h3>Q2: Not Urgent &amp; Important</h3>
+                    <textarea id="quadrant-q2" rows="5" placeholder="Strategic work, planning, relationships, and personal growth."></textarea>
+                </div>
+                <div class="matrix__cell" data-quadrant="q3">
+                    <h3>Q3: Urgent &amp; Not Important</h3>
+                    <textarea id="quadrant-q3" rows="5" placeholder="Interruptions and tasks to delegate or minimize."></textarea>
+                </div>
+                <div class="matrix__cell" data-quadrant="q4">
+                    <h3>Q4: Not Urgent &amp; Not Important</h3>
+                    <textarea id="quadrant-q4" rows="5" placeholder="Activities to reduce so you can focus on what matters."></textarea>
+                </div>
+            </div>
         </section>
-    </div>
+
+        <section class="planner__section" aria-labelledby="weekly-schedule-title">
+            <h2 id="weekly-schedule-title">Weekly Schedule</h2>
+            <p class="section-intro">Block time for your big rocks first, then arrange supporting tasks around them.</p>
+            <div class="table-wrapper table-wrapper--scroll">
+                <table class="schedule-table">
+                    <thead>
+                        <tr>
+                            <th scope="col">Time Block</th>
+                            <th scope="col">Monday</th>
+                            <th scope="col">Tuesday</th>
+                            <th scope="col">Wednesday</th>
+                            <th scope="col">Thursday</th>
+                            <th scope="col">Friday</th>
+                            <th scope="col">Saturday</th>
+                            <th scope="col">Sunday</th>
+                        </tr>
+                    </thead>
+                    <tbody>
+                        <tr>
+                            <th scope="row">Morning</th>
+                            <td><textarea data-day="monday" data-block="morning" rows="4" placeholder="Focus work, key meetings, reflection..."></textarea></td>
+                            <td><textarea data-day="tuesday" data-block="morning" rows="4"></textarea></td>
+                            <td><textarea data-day="wednesday" data-block="morning" rows="4"></textarea></td>
+                            <td><textarea data-day="thursday" data-block="morning" rows="4"></textarea></td>
+                            <td><textarea data-day="friday" data-block="morning" rows="4"></textarea></td>
+                            <td><textarea data-day="saturday" data-block="morning" rows="4"></textarea></td>
+                            <td><textarea data-day="sunday" data-block="morning" rows="4"></textarea></td>
+                        </tr>
+                        <tr>
+                            <th scope="row">Midday</th>
+                            <td><textarea data-day="monday" data-block="midday" rows="4"></textarea></td>
+                            <td><textarea data-day="tuesday" data-block="midday" rows="4"></textarea></td>
+                            <td><textarea data-day="wednesday" data-block="midday" rows="4"></textarea></td>
+                            <td><textarea data-day="thursday" data-block="midday" rows="4"></textarea></td>
+                            <td><textarea data-day="friday" data-block="midday" rows="4"></textarea></td>
+                            <td><textarea data-day="saturday" data-block="midday" rows="4"></textarea></td>
+                            <td><textarea data-day="sunday" data-block="midday" rows="4"></textarea></td>
+                        </tr>
+                        <tr>
+                            <th scope="row">Afternoon</th>
+                            <td><textarea data-day="monday" data-block="afternoon" rows="4"></textarea></td>
+                            <td><textarea data-day="tuesday" data-block="afternoon" rows="4"></textarea></td>
+                            <td><textarea data-day="wednesday" data-block="afternoon" rows="4"></textarea></td>
+                            <td><textarea data-day="thursday" data-block="afternoon" rows="4"></textarea></td>
+                            <td><textarea data-day="friday" data-block="afternoon" rows="4"></textarea></td>
+                            <td><textarea data-day="saturday" data-block="afternoon" rows="4"></textarea></td>
+                            <td><textarea data-day="sunday" data-block="afternoon" rows="4"></textarea></td>
+                        </tr>
+                        <tr>
+                            <th scope="row">Evening</th>
+                            <td><textarea data-day="monday" data-block="evening" rows="4"></textarea></td>
+                            <td><textarea data-day="tuesday" data-block="evening" rows="4"></textarea></td>
+                            <td><textarea data-day="wednesday" data-block="evening" rows="4"></textarea></td>
+                            <td><textarea data-day="thursday" data-block="evening" rows="4"></textarea></td>
+                            <td><textarea data-day="friday" data-block="evening" rows="4"></textarea></td>
+                            <td><textarea data-day="saturday" data-block="evening" rows="4"></textarea></td>
+                            <td><textarea data-day="sunday" data-block="evening" rows="4"></textarea></td>
+                        </tr>
+                    </tbody>
+                </table>
+            </div>
+        </section>
+
+        <section class="planner__section" aria-labelledby="weekly-review-title">
+            <h2 id="weekly-review-title">Weekly Review</h2>
+            <p class="section-intro">Note key learnings, victories, and adjustments for the coming week.</p>
+            <textarea id="weekly-review" name="weekly-review" rows="4" placeholder="Reflect on progress, energy, and relationships..."></textarea>
+        </section>
+    </main>
 </body>
 </html>

--- a/js/planner.js
+++ b/js/planner.js
@@ -1,0 +1,277 @@
+const STORAGE_KEY = "coveyWeeklyPlanner";
+const DAYS = [
+    "monday",
+    "tuesday",
+    "wednesday",
+    "thursday",
+    "friday",
+    "saturday",
+    "sunday"
+];
+const BLOCKS = ["morning", "midday", "afternoon", "evening"];
+const QUADRANTS = ["q1", "q2", "q3", "q4"];
+
+let plannerState = createDefaultState();
+
+const weekStartInput = document.getElementById("week-start");
+const weeklyFocusInput = document.getElementById("weekly-focus");
+const weeklyReviewInput = document.getElementById("weekly-review");
+const addRoleButton = document.getElementById("add-role");
+const resetButton = document.getElementById("reset-planner");
+const rolesBody = document.getElementById("roles-body");
+const quadrantInputs = QUADRANTS.map((key) => document.getElementById(`quadrant-${key}`));
+const scheduleInputs = Array.from(document.querySelectorAll("textarea[data-day][data-block]"));
+
+function createDefaultState() {
+    const schedule = {};
+    DAYS.forEach((day) => {
+        schedule[day] = {};
+        BLOCKS.forEach((block) => {
+            schedule[day][block] = "";
+        });
+    });
+
+    return {
+        weekStart: "",
+        weeklyFocus: "",
+        roles: [{ role: "", goal: "" }],
+        quadrants: {
+            q1: "",
+            q2: "",
+            q3: "",
+            q4: ""
+        },
+        schedule,
+        weeklyReview: ""
+    };
+}
+
+function loadState() {
+    try {
+        const raw = localStorage.getItem(STORAGE_KEY);
+        if (!raw) {
+            return createDefaultState();
+        }
+
+        const parsed = JSON.parse(raw);
+        const base = createDefaultState();
+        return {
+            ...base,
+            ...parsed,
+            roles: Array.isArray(parsed.roles) && parsed.roles.length
+                ? parsed.roles.map((entry) => ({ role: entry.role || "", goal: entry.goal || "" }))
+                : base.roles,
+            quadrants: {
+                ...base.quadrants,
+                ...(parsed.quadrants || {})
+            },
+            schedule: mergeSchedule(base.schedule, parsed.schedule || {}),
+            weeklyReview: parsed.weeklyReview || ""
+        };
+    } catch (error) {
+        console.error("Unable to load planner state", error);
+        return createDefaultState();
+    }
+}
+
+function mergeSchedule(baseSchedule, storedSchedule) {
+    const schedule = { ...baseSchedule };
+    DAYS.forEach((day) => {
+        schedule[day] = { ...baseSchedule[day] };
+        if (storedSchedule[day]) {
+            BLOCKS.forEach((block) => {
+                schedule[day][block] = storedSchedule[day][block] || "";
+            });
+        }
+    });
+    return schedule;
+}
+
+function saveState() {
+    try {
+        localStorage.setItem(STORAGE_KEY, JSON.stringify(plannerState));
+    } catch (error) {
+        console.error("Unable to save planner state", error);
+    }
+}
+
+function renderRoles() {
+    if (!plannerState.roles.length) {
+        plannerState.roles.push({ role: "", goal: "" });
+    }
+
+    rolesBody.innerHTML = "";
+
+    plannerState.roles.forEach((entry, index) => {
+        const row = document.createElement("tr");
+        row.classList.add("role-row");
+
+        const roleCell = document.createElement("td");
+        const roleInput = document.createElement("input");
+        roleInput.type = "text";
+        roleInput.placeholder = "Leader, Parent, Student...";
+        roleInput.value = entry.role || "";
+        roleInput.dataset.index = index;
+        roleInput.dataset.field = "role";
+        roleInput.addEventListener("input", handleRoleChange);
+        roleCell.appendChild(roleInput);
+
+        const goalCell = document.createElement("td");
+        const goalInput = document.createElement("input");
+        goalInput.type = "text";
+        goalInput.placeholder = "Define one meaningful weekly outcome";
+        goalInput.value = entry.goal || "";
+        goalInput.dataset.index = index;
+        goalInput.dataset.field = "goal";
+        goalInput.addEventListener("input", handleRoleChange);
+        goalCell.appendChild(goalInput);
+
+        const actionCell = document.createElement("td");
+        const removeButton = document.createElement("button");
+        removeButton.type = "button";
+        removeButton.className = "remove-role";
+        removeButton.textContent = "Remove";
+        removeButton.dataset.index = index;
+        removeButton.disabled = plannerState.roles.length === 1;
+        removeButton.addEventListener("click", handleRoleRemoval);
+        actionCell.appendChild(removeButton);
+
+        row.appendChild(roleCell);
+        row.appendChild(goalCell);
+        row.appendChild(actionCell);
+
+        rolesBody.appendChild(row);
+    });
+}
+
+function handleRoleChange(event) {
+    const index = Number(event.target.dataset.index);
+    const field = event.target.dataset.field;
+    if (Number.isInteger(index) && field && plannerState.roles[index]) {
+        plannerState.roles[index][field] = event.target.value;
+        saveState();
+    }
+}
+
+function handleRoleRemoval(event) {
+    const index = Number(event.target.dataset.index);
+    if (!Number.isInteger(index) || plannerState.roles.length === 1) {
+        return;
+    }
+    plannerState.roles.splice(index, 1);
+    renderRoles();
+    saveState();
+}
+
+function handleAddRole() {
+    plannerState.roles.push({ role: "", goal: "" });
+    renderRoles();
+    saveState();
+}
+
+function applyStateToInputs() {
+    if (weekStartInput) {
+        weekStartInput.value = plannerState.weekStart || "";
+    }
+    if (weeklyFocusInput) {
+        weeklyFocusInput.value = plannerState.weeklyFocus || "";
+    }
+    if (weeklyReviewInput) {
+        weeklyReviewInput.value = plannerState.weeklyReview || "";
+    }
+
+    quadrantInputs.forEach((input, index) => {
+        if (input) {
+            const key = QUADRANTS[index];
+            input.value = plannerState.quadrants[key] || "";
+        }
+    });
+
+    scheduleInputs.forEach((textarea) => {
+        const day = textarea.dataset.day;
+        const block = textarea.dataset.block;
+        if (day && block && plannerState.schedule[day]) {
+            textarea.value = plannerState.schedule[day][block] || "";
+        }
+    });
+
+    renderRoles();
+}
+
+function handleScheduleInput(event) {
+    const day = event.target.dataset.day;
+    const block = event.target.dataset.block;
+    if (day && block && plannerState.schedule[day]) {
+        plannerState.schedule[day][block] = event.target.value;
+        saveState();
+    }
+}
+
+function handleQuadrantInput(event) {
+    const quadrant = event.target.id.replace("quadrant-", "");
+    if (plannerState.quadrants[quadrant] !== undefined) {
+        plannerState.quadrants[quadrant] = event.target.value;
+        saveState();
+    }
+}
+
+function bindEventListeners() {
+    if (weekStartInput) {
+        weekStartInput.addEventListener("change", (event) => {
+            plannerState.weekStart = event.target.value;
+            saveState();
+        });
+    }
+
+    if (weeklyFocusInput) {
+        weeklyFocusInput.addEventListener("input", (event) => {
+            plannerState.weeklyFocus = event.target.value;
+            saveState();
+        });
+    }
+
+    if (weeklyReviewInput) {
+        weeklyReviewInput.addEventListener("input", (event) => {
+            plannerState.weeklyReview = event.target.value;
+            saveState();
+        });
+    }
+
+    scheduleInputs.forEach((textarea) => {
+        textarea.addEventListener("input", handleScheduleInput);
+    });
+
+    quadrantInputs.forEach((input) => {
+        if (input) {
+            input.addEventListener("input", handleQuadrantInput);
+        }
+    });
+
+    if (addRoleButton) {
+        addRoleButton.addEventListener("click", handleAddRole);
+    }
+
+    if (resetButton) {
+        resetButton.addEventListener("click", handleResetPlanner);
+    }
+}
+
+function handleResetPlanner() {
+    const shouldReset = window.confirm("Clear all planner data for this week?");
+    if (!shouldReset) {
+        return;
+    }
+    plannerState = createDefaultState();
+    try {
+        localStorage.removeItem(STORAGE_KEY);
+    } catch (error) {
+        console.error("Unable to clear planner state", error);
+    }
+    applyStateToInputs();
+}
+
+(function init() {
+    plannerState = loadState();
+    bindEventListeners();
+    applyStateToInputs();
+})();


### PR DESCRIPTION
## Summary
- replace the placeholder menu page with a Covey Habit 3 weekly planner featuring focus, roles, quadrants, schedule, and review sections
- restyle the page with a minimalist black/white/red theme that keeps attention on priorities
- add a client-side planner script that saves inputs locally, supports dynamic roles, and keeps the priority matrix and schedule in sync

## Testing
- No automated tests (static site)


------
https://chatgpt.com/codex/tasks/task_e_68dab32f12fc83208ca421b3383d20db